### PR TITLE
Get things working on Debian 10, tcl 8.6 and Tk 8.6

### DIFF
--- a/demos/dragger.tcl
+++ b/demos/dragger.tcl
@@ -32,7 +32,7 @@
 # $Id: demo.tcl,v 1.1 1997/09/17 21:10:23 donal Exp donal $
 
 # Now we make cunning use of the backslash/shell trick \
-[ -x `dirname $0`/../shapewish ] && exec `dirname $0`/../shapewish $0 ${1+"$@"} || exec wish8.0 $0 ${1+"$@"} || { echo "`basename $0`: couldn't start wish" >&2 ; exit 1; }
+[ -x `dirname $0`/../shapewish ] && exec `dirname $0`/../shapewish $0 ${1+"$@"} || exec wish $0 ${1+"$@"} || { echo "`basename $0`: couldn't start wish" >&2 ; exit 1; }
 
 set dir [file join [pwd] [file dirname [info script]] ..]
 lappend auto_path [file join $dir ..]

--- a/demos/dragger.tcl
+++ b/demos/dragger.tcl
@@ -34,7 +34,9 @@
 # Now we make cunning use of the backslash/shell trick \
 [ -x `dirname $0`/../shapewish ] && exec `dirname $0`/../shapewish $0 ${1+"$@"} || exec wish $0 ${1+"$@"} || { echo "`basename $0`: couldn't start wish" >&2 ; exit 1; }
 
-set dir [file join [pwd] [file dirname [info script]] ..]
+set dir [file join [pwd] [file dirname [info script]] .]
+package ifneeded Shape 0.4 "package require Tk 8\n\
+        [list tclPkgSetup "$dir/../unix/" Shape 0.4 {{libshape04.so.1.0 load shape}}]"
 lappend auto_path [file join $dir ..]
 package require Shape
 

--- a/demos/fancytext.tcl
+++ b/demos/fancytext.tcl
@@ -32,7 +32,7 @@
 # $Id: demo.tcl,v 1.1 1997/09/17 21:10:23 donal Exp donal $
 
 # Now we make cunning use of the backslash/shell trick \
-[ -x `dirname $0`/../shapewish ] && exec `dirname $0`/../shapewish $0 ${1+"$@"} || exec wish8.0 $0 ${1+"$@"} || { echo "`basename $0`: couldn't start wish" >&2 ; exit 1; }
+[ -x `dirname $0`/../shapewish ] && exec `dirname $0`/../shapewish $0 ${1+"$@"} || exec wish $0 ${1+"$@"} || { echo "`basename $0`: couldn't start wish" >&2 ; exit 1; }
 
 set dir [file join [pwd] [file dirname [info script]] ..]
 lappend auto_path [file join $dir ..]

--- a/demos/fancytext.tcl
+++ b/demos/fancytext.tcl
@@ -34,7 +34,9 @@
 # Now we make cunning use of the backslash/shell trick \
 [ -x `dirname $0`/../shapewish ] && exec `dirname $0`/../shapewish $0 ${1+"$@"} || exec wish $0 ${1+"$@"} || { echo "`basename $0`: couldn't start wish" >&2 ; exit 1; }
 
-set dir [file join [pwd] [file dirname [info script]] ..]
+set dir [file join [pwd] [file dirname [info script]] .]
+package ifneeded Shape 0.4 "package require Tk 8\n\
+        [list tclPkgSetup "$dir/../unix/" Shape 0.4 {{libshape04.so.1.0 load shape}}]"
 lappend auto_path [file join $dir ..]
 package require Shape
 

--- a/demos/fancytext.tcl
+++ b/demos/fancytext.tcl
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-# dragger.tcl ---
+# fancytext.tcl ---
 #
-#	Quick demo using the shape library to provide a coloured cursor
+#	Make a piece of text look interesting by suggesting the shape of the
+#	letters
 #
 # Copyright (c) 1997 by Donal K. Fellows
 #

--- a/demos/fingerprint.tcl
+++ b/demos/fingerprint.tcl
@@ -5,7 +5,7 @@
 # a little in order to increase its effectiveness.
 
 # Now we make cunning use of the backslash/shell trick \
-[ -x `dirname $0`/../shapewish ] && exec `dirname $0`/../shapewish $0 ${1+"$@"} || exec wish8.0 $0 ${1+"$@"} || { echo "`basename $0`: couldn't start wish" >&2 ; exit 1; }
+[ -x `dirname $0`/../shapewish ] && exec `dirname $0`/../shapewish $0 ${1+"$@"} || exec wish $0 ${1+"$@"} || { echo "`basename $0`: couldn't start wish" >&2 ; exit 1; }
 
 set dir [file join [pwd] [file dirname [info script]] ..]
 lappend auto_path [file join $dir ..]

--- a/demos/fingerprint.tcl
+++ b/demos/fingerprint.tcl
@@ -7,7 +7,9 @@
 # Now we make cunning use of the backslash/shell trick \
 [ -x `dirname $0`/../shapewish ] && exec `dirname $0`/../shapewish $0 ${1+"$@"} || exec wish $0 ${1+"$@"} || { echo "`basename $0`: couldn't start wish" >&2 ; exit 1; }
 
-set dir [file join [pwd] [file dirname [info script]] ..]
+set dir [file join [pwd] [file dirname [info script]] .]
+package ifneeded Shape 0.4 "package require Tk 8\n\
+        [list tclPkgSetup "$dir/../unix/" Shape 0.4 {{libshape04.so.1.0 load shape}}]"
 lappend auto_path [file join $dir ..]
 package require Shape
 

--- a/generic/shape.c
+++ b/generic/shape.c
@@ -428,7 +428,7 @@ shapePhoto(
 static int
 shapeSetUpdateOps(
     Tk_Window tkwin0,
-    Tcl_Interp *interp;
+    Tcl_Interp *interp,
     int opnum,
     int objc,
     Tcl_Obj *const objv[])

--- a/include/panic.h
+++ b/include/panic.h
@@ -2,7 +2,7 @@
 #define PANIC_H
 
 #ifdef __GNUC__
-EXTERN void	panic(char *message, ...) __attribute__((__noreturn__ , __format__(printf,1,2)));
+/* EXTERN void	panic(char *message, ...) __attribute__((__noreturn__ , __format__(printf,1,2))); */
 #else
 EXTERN void	panic(char *message, ...);
 #endif

--- a/unix/shapeUnixImpl.c
+++ b/unix/shapeUnixImpl.c
@@ -13,7 +13,7 @@
 #include <tk.h>				/* Includes conventional X stuff. */
 #include <X11/Xutil.h>			/* For Region declaration. */
 #include <X11/extensions/shape.h>
-#include "shape.h"
+#include "shapeInt.h"
 
 #ifdef DKF_SHAPE_DEBUGGING
 static int
@@ -364,11 +364,11 @@ int
 Shape_CombineWindow(
     Tcl_Interp *interp,
     Tk_Window tkwin,
-    Tk_Window srcwin,
     int kind,
     int op,
     int x,
-    int y)
+    int y,
+    Tk_Window srcwin)
 {
     Display *dpy  = Tk_Display(tkwin);
     Display *sdpy = Tk_Display(srcwin);


### PR DESCRIPTION
I am building this shape extension as follows on Debian 10.

`$ cd shape/unix`
`$ ./configure --with-tclconf=/usr/lib/tcl8.6 --with-tkconf=/usr/lib`

It doesn't work out-of-the-box but after applying the attached patches I get a `unix/libshape04.so.1.0` binary.

I've also included some patches to get the demos working but I'm less sure of those because there seems to be something I don't understand about how `unix/pkgIndex.tcl` is supposed to work.


Please see the commit messages themselves for all the details.

Hopefully these patches are useful but please let me know if you need any more information.

-- 
andyjpb